### PR TITLE
Add missing `require 'fluent/input'`

### DIFF
--- a/lib/fluent/plugin/in_mysql_appender.rb
+++ b/lib/fluent/plugin/in_mysql_appender.rb
@@ -1,3 +1,5 @@
+require 'fluent/input'
+
 module Fluent
   class MysqlAppenderInput < Fluent::Input
     Plugin.register_input('mysql_appender', self)

--- a/lib/fluent/plugin/in_mysql_appender_multi.rb
+++ b/lib/fluent/plugin/in_mysql_appender_multi.rb
@@ -1,3 +1,5 @@
+require 'fluent/input'
+
 module Fluent
   class MysqlAppenderMultiInput < Fluent::Input
     Plugin.register_input('mysql_appender_multi', self)


### PR DESCRIPTION
To work with Fluentd v1 compatibility layer, v0.12 input plugin must require `fluent/input`.